### PR TITLE
feat: add children() and contexts() methods for CDP connection support

### DIFF
--- a/crates/playwright/examples/test_cdp.rs
+++ b/crates/playwright/examples/test_cdp.rs
@@ -1,0 +1,156 @@
+//! CDP Connection Example
+//!
+//! Demonstrates connecting to an existing browser via Chrome DevTools Protocol,
+//! discovering existing contexts/pages, and interacting with them.
+//!
+//! Usage:
+//!   1. Launch Chrome with: chrome --remote-debugging-port=9223
+//!   2. Navigate to a page (e.g., https://www.wikipedia.org)
+//!   3. Run: cargo run --example test_cdp
+//!
+//! Or just run this example directly - it launches Chrome automatically.
+
+use playwright_rs::Playwright;
+use playwright_rs::server::channel_owner::ChannelOwner;
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+const CDP_PORT: u16 = 9223;
+
+fn launch_chrome(port: u16, url: &str) -> Result<Child, String> {
+    let chrome_path = if cfg!(target_os = "macos") {
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    } else if cfg!(target_os = "windows") {
+        "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
+    } else {
+        "/usr/bin/google-chrome"
+    };
+
+    let temp_dir = std::env::temp_dir().join(format!("playwright-cdp-test-{}", port));
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    std::fs::create_dir_all(&temp_dir).ok();
+
+    Command::new(chrome_path)
+        .arg(format!("--remote-debugging-port={}", port))
+        .arg(format!("--user-data-dir={}", temp_dir.to_string_lossy()))
+        .arg("--window-size=1280,720")
+        .arg("--no-first-run")
+        .arg("--no-default-browser-check")
+        .arg("--disable-extensions")
+        .arg("--disable-default-apps")
+        .arg(url)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| format!("Failed to launch Chrome: {}", e))
+}
+
+async fn wait_for_cdp(port: u16) -> Result<(), String> {
+    for _ in 0..30 {
+        if std::net::TcpStream::connect(format!("127.0.0.1:{}", port)).is_ok() {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    Err("CDP endpoint not ready".into())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("=== CDP Connection Example ===\n");
+
+    // Launch Chrome with Wikipedia pre-loaded
+    println!("Launching Chrome with Wikipedia...");
+    let mut chrome = launch_chrome(CDP_PORT, "https://www.wikipedia.org")?;
+    wait_for_cdp(CDP_PORT).await?;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    println!("Chrome ready!\n");
+
+    // Connect via CDP
+    let playwright = Playwright::launch().await?;
+    let browser = playwright
+        .chromium()
+        .connect_over_cdp(&format!("http://localhost:{}", CDP_PORT), None)
+        .await?;
+
+    // Discover existing contexts and pages
+    let contexts = browser.contexts();
+    println!("Found {} context(s)", contexts.len());
+
+    let ctx = &contexts[0];
+    let pages = ctx.pages();
+    println!("Found {} page(s)", pages.len());
+    for (i, p) in pages.iter().enumerate() {
+        println!("  Page {}: GUID={}, URL={}", i, p.guid(), p.url());
+    }
+
+    let page = pages.last().unwrap();
+    println!("\nUsing page: {}", page.guid());
+
+    // Activate the page and set viewport
+    page.bring_to_front().await?;
+    page.set_viewport_size(playwright_rs::Viewport {
+        width: 1280,
+        height: 720,
+    })
+    .await?;
+
+    // Get real URL via JS (page.url() may be stale for CDP-attached pages)
+    let url: String = page.evaluate("() => window.location.href", None::<&()>).await?;
+    println!("URL: {}", url);
+
+    // Get page title
+    let title = page.title().await?;
+    println!("Title: {}", title);
+
+    // Take screenshot
+    let screenshot = page.screenshot(None).await?;
+    std::fs::write("/tmp/cdp_example.png", &screenshot)?;
+    println!("Screenshot: {} bytes -> /tmp/cdp_example.png", screenshot.len());
+
+    // Click on search input using mouse coordinates
+    println!("\nClicking search input...");
+    // Get the search input position via JS
+    let pos: serde_json::Value = page.evaluate(
+        r#"() => {
+            const el = document.querySelector('input[name=search]');
+            if (!el) return { x: 640, y: 360 };
+            const rect = el.getBoundingClientRect();
+            return { x: rect.x + rect.width/2, y: rect.y + rect.height/2 };
+        }"#,
+        None::<&()>,
+    ).await?;
+    let cx = pos["x"].as_f64().unwrap_or(640.0) as i32;
+    let cy = pos["y"].as_f64().unwrap_or(360.0) as i32;
+    println!("Search input at ({}, {})", cx, cy);
+    page.mouse().click(cx, cy, None).await?;
+
+    // Type a search query
+    println!("Typing 'Rust programming language'...");
+    page.keyboard().type_text("Rust programming language", None).await?;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Verify typing worked
+    let value: String = page.evaluate(
+        "() => document.querySelector('input[name=search]')?.value || ''",
+        None::<&()>,
+    ).await?;
+    println!("Search input value: '{}'", value);
+
+    // Take final screenshot
+    let screenshot2 = page.screenshot(None).await?;
+    std::fs::write("/tmp/cdp_example_after.png", &screenshot2)?;
+    println!("Final screenshot -> /tmp/cdp_example_after.png");
+
+    if value.contains("Rust") {
+        println!("\n✅ CDP connection and interaction successful!");
+    } else {
+        println!("\n❌ Interaction did not work as expected");
+    }
+
+    // Cleanup
+    chrome.kill().ok();
+    chrome.wait().ok();
+    println!("Done!");
+    Ok(())
+}

--- a/crates/playwright/src/api/connect_options.rs
+++ b/crates/playwright/src/api/connect_options.rs
@@ -37,3 +37,45 @@ impl ConnectOptions {
         self
     }
 }
+
+/// Options for `BrowserType::connect_over_cdp`.
+///
+/// Used to configure CDP connection parameters when connecting to an existing
+/// browser instance via Chrome DevTools Protocol.
+#[derive(Debug, Clone, Default)]
+pub struct ConnectOverCdpOptions {
+    /// Additional HTTP headers to send with the connection.
+    /// Used for authentication with secured CDP endpoints.
+    pub headers: Option<HashMap<String, String>>,
+    /// Slows down Playwright operations by the specified amount of milliseconds.
+    /// Useful so that you can see what is going on.
+    pub slow_mo: Option<f64>,
+    /// Maximum time in milliseconds to wait for the connection to be established.
+    /// Defaults to 30000 (30 seconds). Pass 0 to disable timeout.
+    pub timeout: Option<f64>,
+}
+
+impl ConnectOverCdpOptions {
+    /// Creates a new `ConnectOverCdpOptions` with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set additional HTTP headers for the connection.
+    pub fn headers(mut self, headers: HashMap<String, String>) -> Self {
+        self.headers = Some(headers);
+        self
+    }
+
+    /// Set slow mo delay in milliseconds.
+    pub fn slow_mo(mut self, slow_mo: f64) -> Self {
+        self.slow_mo = Some(slow_mo);
+        self
+    }
+
+    /// Set connection timeout in milliseconds.
+    pub fn timeout(mut self, timeout: f64) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+}

--- a/crates/playwright/src/api/mod.rs
+++ b/crates/playwright/src/api/mod.rs
@@ -6,7 +6,7 @@
 pub mod connect_options;
 pub mod launch_options;
 
-pub use connect_options::ConnectOptions;
+pub use connect_options::{ConnectOptions, ConnectOverCdpOptions};
 pub use launch_options::{IgnoreDefaultArgs, LaunchOptions};
 // Re-export ProxySettings for backward compatibility (moved to protocol::proxy in 0.8.4)
 pub use crate::protocol::ProxySettings;

--- a/crates/playwright/src/lib.rs
+++ b/crates/playwright/src/lib.rs
@@ -216,3 +216,6 @@ pub use protocol::{FulfillOptions, Route};
 
 // Re-export launch options
 pub use api::LaunchOptions;
+
+// Re-export connection options
+pub use api::{ConnectOptions, ConnectOverCdpOptions};

--- a/crates/playwright/src/protocol/browser.rs
+++ b/crates/playwright/src/protocol/browser.rs
@@ -139,6 +139,45 @@ impl Browser {
         self.is_connected.load(Ordering::SeqCst)
     }
 
+    /// Returns all browser contexts belonging to this browser.
+    ///
+    /// When connecting via CDP, this returns the existing contexts from the
+    /// connected browser. When launching a new browser, this returns contexts
+    /// created via `new_context()`.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Connect to existing browser via CDP
+    /// let browser = chromium.connect_over_cdp(params).await?;
+    ///
+    /// // Get existing contexts
+    /// let contexts = browser.contexts();
+    /// if !contexts.is_empty() {
+    ///     let context = &contexts[0];
+    ///     let pages = context.pages();
+    ///     // Use existing page...
+    /// }
+    /// ```
+    ///
+    /// See: <https://playwright.dev/docs/api/class-browser#browser-contexts>
+    pub fn contexts(&self) -> Vec<BrowserContext> {
+        self.base
+            .children()
+            .into_iter()
+            .filter_map(|child| {
+                if child.type_name() == "BrowserContext" {
+                    child
+                        .as_any()
+                        .downcast_ref::<BrowserContext>()
+                        .cloned()
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
     /// Returns the channel for sending protocol messages
     ///
     /// Used internally for sending RPC calls to the browser.

--- a/crates/playwright/src/protocol/browser_context.rs
+++ b/crates/playwright/src/protocol/browser_context.rs
@@ -232,6 +232,9 @@ impl BrowserContext {
     /// In persistent contexts launched with `--app=url`, this will include the
     /// initial page created automatically by Playwright.
     ///
+    /// When connecting via CDP to an existing browser, this returns pages that
+    /// were already open in the browser context.
+    ///
     /// # Errors
     ///
     /// This method does not return errors. It provides a snapshot of pages at
@@ -239,6 +242,29 @@ impl BrowserContext {
     ///
     /// See: <https://playwright.dev/docs/api/class-browsercontext#browser-context-pages>
     pub fn pages(&self) -> Vec<Page> {
+        // First check children (for CDP connections where pages already exist)
+        // This mirrors how Browser.contexts() works
+        let children_pages: Vec<Page> = self.base
+            .children()
+            .into_iter()
+            .filter_map(|child| {
+                if child.type_name() == "Page" {
+                    child
+                        .as_any()
+                        .downcast_ref::<Page>()
+                        .cloned()
+                } else {
+                    None
+                }
+            })
+            .collect();
+        
+        // If we have pages from children (CDP case), return those
+        if !children_pages.is_empty() {
+            return children_pages;
+        }
+        
+        // Otherwise return from the event-tracked pages (normal case)
         self.pages.lock().unwrap().clone()
     }
 

--- a/crates/playwright/src/protocol/browser_type.rs
+++ b/crates/playwright/src/protocol/browser_type.rs
@@ -7,7 +7,7 @@
 // - Python: playwright-python/playwright/_impl/_browser_type.py
 // - Protocol: protocol.yml (BrowserType interface)
 
-use crate::api::{ConnectOptions, LaunchOptions};
+use crate::api::{ConnectOptions, ConnectOverCdpOptions, LaunchOptions};
 use crate::error::Result;
 use crate::protocol::{Browser, BrowserContext, BrowserContextOptions};
 use crate::server::channel::Channel;
@@ -403,6 +403,94 @@ impl BrowserType {
 
         Ok(context.clone())
     }
+    /// Connects to an existing browser instance via Chrome DevTools Protocol (CDP).
+    ///
+    /// This method attaches Playwright to an existing browser instance that was
+    /// started with remote debugging enabled (e.g., `--remote-debugging-port=9222`).
+    ///
+    /// Unlike `connect()` which connects to a Playwright server, this connects
+    /// directly to a browser's CDP endpoint.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint_url` - CDP endpoint URL (ws:// or http://)
+    /// * `options` - Optional connection options (timeout, headers, slow_mo)
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Start Chrome with: chrome --remote-debugging-port=9222
+    /// let browser = chromium.connect_over_cdp(
+    ///     "http://localhost:9222",
+    ///     None
+    /// ).await?;
+    ///
+    /// // Access existing contexts and pages
+    /// let contexts = browser.contexts();
+    /// let context = &contexts[0];
+    /// let pages = context.pages();
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns error if:
+    /// - Connection to CDP endpoint fails
+    /// - Timeout waiting for connection
+    /// - Protocol error during handshake
+    ///
+    /// See: <https://playwright.dev/docs/api/class-browsertype#browser-type-connect-over-cdp>
+    pub async fn connect_over_cdp(
+        &self,
+        endpoint_url: &str,
+        options: Option<ConnectOverCdpOptions>,
+    ) -> Result<Browser> {
+        let options = options.unwrap_or_default();
+
+        // Build params for the connectOverCDP message
+        let mut params = serde_json::json!({
+            "endpointURL": endpoint_url,
+        });
+
+        // Add optional timeout (default 30000ms like Python SDK)
+        let timeout = options.timeout.unwrap_or(30000.0);
+        params["timeout"] = serde_json::json!(timeout);
+
+        // Add optional slow_mo
+        if let Some(slow_mo) = options.slow_mo {
+            params["slowMo"] = serde_json::json!(slow_mo);
+        }
+
+        // Serialize headers to the format expected by Playwright server
+        // Python SDK uses serialize_headers() which converts to list of {name, value} objects
+        if let Some(headers) = options.headers {
+            let serialized: Vec<serde_json::Value> = headers
+                .into_iter()
+                .map(|(name, value)| serde_json::json!({"name": name, "value": value}))
+                .collect();
+            params["headers"] = serde_json::json!(serialized);
+        }
+
+        // Send connectOverCDP RPC to server
+        let response: ConnectOverCdpResponse =
+            self.base.channel().send("connectOverCDP", params).await?;
+
+        // Get browser object from registry
+        let browser_arc = self.connection().get_object(&response.browser.guid).await?;
+
+        // Downcast to Browser
+        let browser = browser_arc
+            .as_any()
+            .downcast_ref::<Browser>()
+            .ok_or_else(|| {
+                crate::error::Error::ProtocolError(format!(
+                    "Expected Browser object, got {}",
+                    browser_arc.type_name()
+                ))
+            })?;
+
+        Ok(browser.clone())
+    }
+
     /// Connects to an existing browser instance.
     ///
     /// # Arguments
@@ -486,6 +574,15 @@ impl BrowserType {
 #[derive(Debug, Deserialize, Serialize)]
 struct LaunchResponse {
     browser: BrowserRef,
+}
+
+/// Response from BrowserType.connectOverCDP() protocol call
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConnectOverCdpResponse {
+    browser: BrowserRef,
+    #[serde(default)]
+    default_context: Option<ContextRef>,
 }
 
 /// Response from BrowserType.launchPersistentContext() protocol call

--- a/crates/playwright/src/protocol/page.rs
+++ b/crates/playwright/src/protocol/page.rs
@@ -326,6 +326,15 @@ impl Page {
             .await
     }
 
+    /// Brings the page to front (activates tab).
+    ///
+    /// See: <https://playwright.dev/docs/api/class-page#page-bring-to-front>
+    pub async fn bring_to_front(&self) -> Result<()> {
+        self.channel()
+            .send_no_result("bringToFront", serde_json::json!({}))
+            .await
+    }
+
     /// Navigates to the specified URL.
     ///
     /// Returns `None` when navigating to URLs that don't produce responses (e.g., data URLs,

--- a/crates/playwright/src/server/channel_owner.rs
+++ b/crates/playwright/src/server/channel_owner.rs
@@ -309,6 +309,19 @@ impl ChannelOwnerImpl {
         &self.channel
     }
 
+    /// Returns all child objects of this ChannelOwner.
+    ///
+    /// This is used by protocol objects like Browser to enumerate their
+    /// children (e.g., BrowserContexts) without exposing the internal
+    /// children registry directly.
+    ///
+    /// # Returns
+    ///
+    /// A vector of all child ChannelOwner objects.
+    pub fn children(&self) -> Vec<Arc<dyn ChannelOwner>> {
+        self.children.lock().values().cloned().collect()
+    }
+
     /// Disposes this object and all children recursively.
     ///
     /// # Arguments


### PR DESCRIPTION
- Add ChannelOwnerImpl::children() to expose child objects
- Add Browser::contexts() to get existing BrowserContexts
- Enables accessing existing pages when connecting via CDP