### PR TITLE
Expose TLS backend features in playwright crate

### DIFF
--- a/crates/playwright/Cargo.toml
+++ b/crates/playwright/Cargo.toml
@@ -14,6 +14,12 @@ readme = "../../README.md"
 [lib]
 doctest = false  # Disable doc-tests by default (run with: cargo test --doc)
 
+[features]
+default = ["native-tls"]
+native-tls = ["tokio-tungstenite/native-tls"]
+rustls-tls-native-roots = ["tokio-tungstenite/rustls-tls-native-roots"]
+rustls-tls-webpki-roots = ["tokio-tungstenite/rustls-tls-webpki-roots"]
+
 [dependencies]
 tokio = { workspace = true }
 serde = { workspace = true }
@@ -25,7 +31,7 @@ base64 = "0.22"
 regex = "1.10"
 glob = "0.3"
 mime_guess = "2.0"
-tokio-tungstenite = { version = "0.28", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.28" }
 futures-util = "0.3"
 url = "2.5"
 image = { version = "0.25", default-features = false, features = ["png"] }


### PR DESCRIPTION
Expose `tokio-tungstenite` TLS features (`native-tls`, `rustls-tls-native-roots`, and `rustls-tls-webpki-roots`) to allow consumers to choose their preferred TLS implementation. Defaults to `native-tls`.