### PR TITLE
ci: pin glibc target for fuzz smoke job

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -154,8 +154,11 @@ jobs:
     - name: Run fuzz targets (60s each)
       working-directory: crates/playwright
       run: |
+        # Pin the glibc target: cargo-fuzz otherwise defaults to musl,
+        # whose statically linked libc is incompatible with AddressSanitizer.
         for target in fuzz_parse_value fuzz_parse_result fuzz_serialize_argument; do
-          cargo +nightly fuzz run "$target" -- -max_total_time=60 -timeout=10
+          cargo +nightly fuzz run "$target" \
+            --target x86_64-unknown-linux-gnu -- -max_total_time=60 -timeout=10
         done
 
     - name: Upload crash artifacts


### PR DESCRIPTION
## Problem

The **Fuzz smoke (protocol parsers)** job in `Security & Quality` has failed on every weekly cron since 2026-06-13 (last green: 2026-06-06):

```
error: sanitizer is incompatible with statically linked libc,
       disable it using `-C target-feature=-crt-static`
error[E0463]: can't find crate for `core`
  = note: the `x86_64-unknown-linux-musl` target may not be installed
```

Not a fuzzing crash — the build never reaches the parsers. `cargo-fuzz` began defaulting to the musl target, whose statically linked libc is incompatible with AddressSanitizer. Nothing in the repo sets `--target`, so cargo-fuzz picked it on its own.

It's scheduled-only, so it never gated pushes or releases — but the weekly fuzz smoke has been dark for a month, so a protocol-parser regression in that window would have gone uncaught.

## Fix

Pin `--target x86_64-unknown-linux-gnu` in the fuzz run loop. glibc ships on `ubuntu-latest` and is ASAN-compatible, sidestepping the musl default.

Verified by a `workflow_dispatch` run on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)