### PR TITLE
DO NOT MERGE: v0.14.1 release validation (backport branch)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.playwright-driver
-          key: ${{ runner.os }}-pw-driver-1.60.0
+          key: ${{ runner.os }}-pw-driver-1.60.0-assembled
 
       - name: Cache Playwright Browsers (Linux/macOS)
         if: runner.os != 'Windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ${{ github.workspace }}/.playwright-driver
-        key: ${{ runner.os }}-pw-driver-1.60.0
+        key: ${{ runner.os }}-pw-driver-1.60.0-assembled
 
     - name: Cache Playwright Browsers (Linux/macOS)
       if: runner.os != 'Windows'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-trait"
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -500,6 +500,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1197,7 +1207,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "playwright-rs"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1207,6 +1217,7 @@ dependencies = [
  "clap",
  "criterion",
  "dirs",
+ "flate2",
  "futures-util",
  "glob",
  "image",
@@ -1216,6 +1227,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tar",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1776,6 +1788,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2570,6 +2593,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "xtask"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ a duplicate of the API reference.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=padamson/playwright-rust&type=Date)](https://star-history.com/#padamson/playwright-rust&Date)
+[![Star History Chart](https://api.star-history.com/chart?repos=padamson/playwright-rust&type=date&legend=top-left&sealed_token=Op9aMPhRKMrLuxPN6Gm9tDlM5gQgFHjO9mtlrqq3qU6DWkO5nSao2tjUHuzC3m8RPGKZ0nVsg9Eo1l77UQ4E3t8XOIJfxFOlbWwI3EzojNG70cDCp2c28YVNRYSrl91Tnc-mvTs14Y5Aonm4ri8iI-CPCnPPHvYYNGJsOG8X-Ggt8TtYgQX_5VF_GENT)](https://www.star-history.com/?type=date&repos=padamson%2Fplaywright-rust)
 
 ## Contributing
 

--- a/crates/playwright/CHANGELOG.md
+++ b/crates/playwright/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-07-10
+
+### Security
+
+- **Bumped `crossbeam-epoch` 0.9.18 → 0.9.20 ([RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204)) and `anyhow` 1.0.102 → 1.0.103 ([RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190)) in the repository lockfile.** Both reach this repo only through dev-dependencies (benchmarks and tests), so no consumer of `playwright-rs` was exposed.
+
+### Fixed
+
+- **Driver acquisition survives the shutdown of Microsoft's `playwright.azureedge.net` CDN.** The prebuilt `playwright-<version>-<platform>.zip` driver archives were discontinued with that CDN (they now 404), which broke every fresh build — cold caches, new machines, and CI failed with `environment variable PLAYWRIGHT_DRIVER_VERSION not defined` (issue [#116](https://github.com/padamson/playwright-rust/issues/116)). The build script (and the `cli` feature's `playwright-rs install`) now assemble the driver from two artifacts instead: the `playwright-core` npm tarball (registry.npmjs.org) and a pinned Node.js binary (nodejs.org, currently 24.17.0) — the same model playwright-python uses — laid out identically to the old bundle so runtime behavior is unchanged ([ADR 0006](https://github.com/padamson/playwright-rust/blob/main/docs/adr/0006-driver-acquisition-assemble-locally.md)). The bundled driver stays at 1.60.0; no API changes. A failed download now compiles anyway (the runtime falls back to `PLAYWRIGHT_DRIVER_PATH` or an npm-installed Playwright, failing at launch with `ServerNotFound`) instead of poisoning downstream builds with the missing-env-var compile error, and download errors name the exact URL that failed.
+
 ## [0.14.0] - 2026-06-13
 
 ### Added

--- a/crates/playwright/Cargo.toml
+++ b/crates/playwright/Cargo.toml
@@ -21,7 +21,7 @@ rustls-tls-native-roots = ["tokio-tungstenite/rustls-tls-native-roots"]
 rustls-tls-webpki-roots = ["tokio-tungstenite/rustls-tls-webpki-roots"]
 screenshot-diff = ["dep:image"]
 macros = ["dep:playwright-rs-macros"]
-cli = ["dep:clap", "dep:ureq", "dep:zip"]
+cli = ["dep:clap", "dep:ureq", "dep:zip", "dep:flate2", "dep:tar"]
 
 [dependencies]
 tokio = { workspace = true }
@@ -44,6 +44,10 @@ playwright-rs-macros = { version = "0.1.0", path = "../playwright-rs-macros", op
 clap = { version = "4", features = ["derive"], optional = true }
 ureq = { version = "3.3.0", optional = true }
 zip = { version = "8", optional = true, default-features = false, features = ["deflate"] }
+# .tar.gz handling for the assembled driver (npm playwright-core tarball +
+# the Node dist archive on non-Windows) — see ADR 0006.
+flate2 = { version = "1", optional = true }
+tar = { version = "0.4", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -70,6 +74,10 @@ ureq = "3.3.0"
 # skip zip's default codec set (aes-crypto/bzip2/zstd/lzma/...) — smaller
 # tree and no pull on the encryption stack. Mirrors playwright-rs-trace.
 zip = { version = "8", default-features = false, features = ["deflate"] }
+# .tar.gz for the npm playwright-core tarball + the non-Windows Node dist
+# archive (the driver is assembled from those two artifacts — ADR 0006).
+flate2 = "1"
+tar = "0.4"
 
 [package.metadata.docs.rs]
 # Pin nightly to avoid generic-array 0.14 breakage (doc_auto_cfg removed in Rust 1.92)

--- a/crates/playwright/build.rs
+++ b/crates/playwright/build.rs
@@ -1,8 +1,12 @@
 //! Build script for playwright-rs
 //!
-//! Downloads and extracts the Playwright Node.js driver from Azure CDN.
-//! The runtime side (`src/server/driver.rs`) picks the path up via
-//! compile-time `option_env!()` lookups.
+//! Assembles the Playwright Node.js driver from two artifacts — the
+//! `playwright-core` npm tarball (registry.npmjs.org) and a pinned Node.js
+//! binary (nodejs.org) — into the same `node` + `package/` layout the old
+//! prebuilt CDN zip provided (see ADR 0006; the prebuilt zips were
+//! discontinued when the azureedge CDN shut down). The runtime side
+//! (`src/server/driver.rs`) picks the path up via compile-time
+//! `option_env!()` lookups.
 //!
 //! By default the driver lands in Cargo's `$OUT_DIR` (inside `target/`),
 //! which is fine for local dev. Two env knobs tune it for CI:
@@ -14,18 +18,22 @@
 //!   run. The driver belongs in its own `actions/cache`, like the browsers.
 //! - `PLAYWRIGHT_SKIP_DRIVER_DOWNLOAD` skips the download entirely for
 //!   compile-only jobs (e.g. the MSRV `cargo check`) that never launch a
-//!   browser, saving a ~42 MB fetch.
+//!   browser, saving a ~90 MB fetch.
 
 use std::env;
-use std::fs;
-use std::io;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 const PLAYWRIGHT_VERSION: &str = "1.60.0";
-const DRIVER_BASE_URL: &str = "https://playwright.azureedge.net/builds/driver";
+
+// Download + assembly logic shared with the cli binary (`src/bin/
+// playwright_rs.rs`); pulls in the pure URL/platform mapping from
+// `driver_urls.rs`, which the lib test suite unit-tests.
+include!("src/build_support/driver_assembly.rs");
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=src/build_support/driver_assembly.rs");
+    println!("cargo:rerun-if-changed=src/build_support/driver_urls.rs");
     println!("cargo:rerun-if-env-changed=PLAYWRIGHT_DRIVER_CACHE_DIR");
     println!("cargo:rerun-if-env-changed=PLAYWRIGHT_SKIP_DRIVER_DOWNLOAD");
 
@@ -33,10 +41,7 @@ fn main() {
     // (e.g. MSRV `cargo check`, mutation testing) that never launch a browser.
     if env::var_os("DOCS_RS").is_some() || env::var_os("PLAYWRIGHT_SKIP_DRIVER_DOWNLOAD").is_some()
     {
-        println!("cargo:rustc-env=PLAYWRIGHT_DRIVER_DIR=");
-        println!("cargo:rustc-env=PLAYWRIGHT_DRIVER_VERSION={PLAYWRIGHT_VERSION}");
-        println!("cargo:rustc-env=PLAYWRIGHT_DRIVER_PLATFORM=skipped");
-        println!("cargo:rustc-env=PLAYWRIGHT_DRIVER_DIR_SOURCE=skipped");
+        set_skipped_env_vars("skipped");
         return;
     }
 
@@ -65,22 +70,29 @@ fn main() {
         return;
     }
 
-    println!("cargo:warning=Downloading Playwright driver {PLAYWRIGHT_VERSION} for {platform}...");
+    println!(
+        "cargo:warning=Assembling Playwright driver {PLAYWRIGHT_VERSION} (Node {NODE_VERSION}) for {platform}..."
+    );
 
-    match download_and_extract_driver(&drivers_dir, platform) {
-        Ok(extracted_dir) => {
+    match assemble_driver(&driver_dir, PLAYWRIGHT_VERSION, platform) {
+        Ok(()) => {
             println!(
-                "cargo:warning=Playwright driver downloaded to {}",
-                extracted_dir.display()
+                "cargo:warning=Playwright driver assembled at {}",
+                driver_dir.display()
             );
-            set_output_env_vars(&extracted_dir, platform);
+            set_output_env_vars(&driver_dir, platform);
         }
         Err(e) => {
-            println!("cargo:warning=Failed to download Playwright driver: {e}");
-            println!("cargo:warning=The driver will need to be installed manually or via npm.");
+            // Compile anyway (same shape as the skip path): the runtime
+            // resolution chain can still find a driver via PLAYWRIGHT_DRIVER_PATH
+            // or an npm-installed playwright, and a build without one fails at
+            // launch with ServerNotFound instead of a cryptic missing-env-var
+            // compile error in downstream crates.
+            println!("cargo:warning=Failed to assemble Playwright driver: {e}");
             println!(
-                "cargo:warning=You can set PLAYWRIGHT_DRIVER_PATH to specify driver location."
+                "cargo:warning=Set PLAYWRIGHT_DRIVER_PATH to a driver directory, or install one via npm."
             );
+            set_skipped_env_vars("failed");
         }
     }
 }
@@ -89,114 +101,28 @@ fn main() {
 fn detect_platform() -> &'static str {
     let os = env::consts::OS;
     let arch = env::consts::ARCH;
-
-    match (os, arch) {
-        ("macos", "x86_64") => "mac",
-        ("macos", "aarch64") => "mac-arm64",
-        ("linux", "x86_64") => "linux",
-        ("linux", "aarch64") => "linux-arm64",
-        ("windows", "x86_64") => "win32_x64",
-        ("windows", "aarch64") => "win32_arm64",
-        _ => {
-            println!("cargo:warning=Unsupported platform: {} {}", os, arch);
-            println!("cargo:warning=Defaulting to linux platform");
-            "linux"
-        }
-    }
+    playwright_platform(os, arch).unwrap_or_else(|| {
+        println!("cargo:warning=Unsupported platform: {os} {arch}");
+        println!("cargo:warning=Defaulting to linux platform");
+        "linux"
+    })
 }
 
-/// Download and extract the Playwright driver.
-//
-// TODO: this download/extract routine is duplicated in
-// `src/bin/playwright_rs.rs::ensure_driver_in_user_cache` for v0.x.
-// Extract to a shared module (via `include!()` or an internal crate)
-// once the architecture stabilizes.
-fn download_and_extract_driver(drivers_dir: &Path, platform: &str) -> io::Result<PathBuf> {
-    // Create drivers directory
-    fs::create_dir_all(drivers_dir)?;
-
-    // Download URL
-    let filename = format!("playwright-{}-{}.zip", PLAYWRIGHT_VERSION, platform);
-    let url = format!("{}/{}", DRIVER_BASE_URL, filename);
-
-    println!("cargo:warning=Downloading from: {}", url);
-
-    // Download the file via ureq (synchronous, minimal dep tree).
-    let mut response = ureq::get(&url)
-        .call()
-        .map_err(|e| io::Error::other(format!("Download failed: {}", e)))?;
-
-    let status = response.status().as_u16();
-    if !(200..300).contains(&status) {
-        return Err(io::Error::other(format!(
-            "Download failed with status: {}",
-            status
-        )));
-    }
-
-    // The driver archive is ~50 MB; ureq's default body limit is 10 MB.
-    // Lift the limit for this trusted Microsoft CDN download.
-    let bytes: Vec<u8> = response
-        .body_mut()
-        .with_config()
-        .limit(u64::MAX)
-        .read_to_vec()
-        .map_err(|e| io::Error::other(format!("Failed to read response: {}", e)))?;
-
-    println!("cargo:warning=Downloaded {} bytes", bytes.len());
-
-    // Extract ZIP file
-    let cursor = io::Cursor::new(bytes);
-    let mut archive = zip::ZipArchive::new(cursor)
-        .map_err(|e| io::Error::other(format!("Failed to open ZIP: {}", e)))?;
-
-    let extract_dir = drivers_dir.join(format!("playwright-{}-{}", PLAYWRIGHT_VERSION, platform));
-
-    println!("cargo:warning=Extracting to: {}", extract_dir.display());
-
-    for i in 0..archive.len() {
-        let mut file = archive
-            .by_index(i)
-            .map_err(|e| io::Error::other(format!("Failed to read ZIP entry: {}", e)))?;
-
-        let outpath = extract_dir.join(file.name());
-
-        if file.is_dir() {
-            fs::create_dir_all(&outpath)?;
-        } else {
-            if let Some(parent) = outpath.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            let mut outfile = fs::File::create(&outpath)?;
-            io::copy(&mut file, &mut outfile)?;
-
-            // Set executable permissions on Unix
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-
-                // Make executable: node binary and any shell scripts
-                if outpath.ends_with("node")
-                    || outpath.extension().and_then(|s| s.to_str()) == Some("sh")
-                {
-                    let mut perms = fs::metadata(&outpath)?.permissions();
-                    perms.set_mode(0o755);
-                    fs::set_permissions(&outpath, perms)?;
-                }
-            }
-        }
-    }
-
+/// Env vars for builds that have no driver on disk (skipped or failed
+/// download): the crate still compiles, and the runtime falls back through
+/// its resolution chain.
+fn set_skipped_env_vars(reason: &str) {
+    println!("cargo:rustc-env=PLAYWRIGHT_DRIVER_DIR=");
+    println!("cargo:rustc-env=PLAYWRIGHT_DRIVER_VERSION={PLAYWRIGHT_VERSION}");
     println!(
-        "cargo:warning=Successfully extracted {} files",
-        archive.len()
+        "cargo:rustc-env=PLAYWRIGHT_DRIVER_PLATFORM={}",
+        detect_platform()
     );
-
-    Ok(extract_dir)
+    println!("cargo:rustc-env=PLAYWRIGHT_DRIVER_DIR_SOURCE={reason}");
 }
 
 /// Set environment variables for use at runtime
-fn set_output_env_vars(driver_dir: &Path, platform: &str) {
+fn set_output_env_vars(driver_dir: &std::path::Path, platform: &str) {
     // Set the driver directory for runtime
     println!(
         "cargo:rustc-env=PLAYWRIGHT_DRIVER_DIR={}",

--- a/crates/playwright/src/bin/playwright_rs.rs
+++ b/crates/playwright/src/bin/playwright_rs.rs
@@ -6,18 +6,14 @@
 //! up the build's `target/`. Running `playwright-rs install` populates
 //! `dirs::cache_dir()/playwright-rust/<version>/`, which the library's
 //! runtime resolution chain probes after the bundled lookup.
-//
-// TODO: the download/extract logic is duplicated from `build.rs` for
-// v0.x. Extract to a shared module (via `include!()` or an internal
-// crate) once the architecture stabilises.
 
 use clap::{Parser, Subcommand};
-use std::fs;
-use std::io;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::ExitCode;
 
-const DRIVER_BASE_URL: &str = "https://playwright.azureedge.net/builds/driver";
+// Download + assembly logic shared with build.rs (see ADR 0006: the driver
+// is assembled from the npm `playwright-core` tarball + a pinned Node binary).
+include!("../build_support/driver_assembly.rs");
 
 #[derive(Parser)]
 #[command(name = "playwright-rs", version, about, long_about = None)]
@@ -104,7 +100,7 @@ async fn run_install(
 
 /// Ensure the Playwright driver exists at
 /// `<cache>/playwright-rust/<version>/playwright-<version>-<platform>/`.
-/// Downloads + extracts from Azure CDN if absent. Returns the driver dir.
+/// Assembles it from npm + nodejs.org if absent. Returns the driver dir.
 fn ensure_driver_in_user_cache(
     version: &str,
     platform: &str,
@@ -120,63 +116,8 @@ fn ensure_driver_in_user_cache(
         return Ok(driver_dir);
     }
 
-    let parent = driver_dir.parent().expect("driver_dir always has a parent");
-    fs::create_dir_all(parent)?;
-
-    let url = format!("{DRIVER_BASE_URL}/playwright-{version}-{platform}.zip");
-    eprintln!("Downloading driver from {url}");
-
-    let mut response = ureq::get(&url).call()?;
-    let status = response.status().as_u16();
-    if !(200..300).contains(&status) {
-        return Err(format!("download failed with status: {status}").into());
-    }
-
-    let bytes: Vec<u8> = response
-        .body_mut()
-        .with_config()
-        .limit(u64::MAX)
-        .read_to_vec()?;
-    eprintln!("Downloaded {} bytes", bytes.len());
-
-    let cursor = io::Cursor::new(bytes);
-    let mut archive = zip::ZipArchive::new(cursor)?;
-    extract_zip_to(&mut archive, &driver_dir)?;
+    eprintln!("Assembling driver {version} (Node {NODE_VERSION}) for {platform}...");
+    assemble_driver(&driver_dir, version, platform)?;
 
     Ok(driver_dir)
-}
-
-fn extract_zip_to(
-    archive: &mut zip::ZipArchive<io::Cursor<Vec<u8>>>,
-    dest: &Path,
-) -> io::Result<()> {
-    fs::create_dir_all(dest)?;
-    for i in 0..archive.len() {
-        let mut file = archive
-            .by_index(i)
-            .map_err(|e| io::Error::other(format!("zip read failed: {e}")))?;
-        let outpath = dest.join(file.name());
-        if file.is_dir() {
-            fs::create_dir_all(&outpath)?;
-        } else {
-            if let Some(parent) = outpath.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            let mut outfile = fs::File::create(&outpath)?;
-            io::copy(&mut file, &mut outfile)?;
-
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                if outpath.ends_with("node")
-                    || outpath.extension().and_then(|s| s.to_str()) == Some("sh")
-                {
-                    let mut perms = fs::metadata(&outpath)?.permissions();
-                    perms.set_mode(0o755);
-                    fs::set_permissions(&outpath, perms)?;
-                }
-            }
-        }
-    }
-    Ok(())
 }

--- a/crates/playwright/src/build_support/driver_assembly.rs
+++ b/crates/playwright/src/build_support/driver_assembly.rs
@@ -1,0 +1,202 @@
+// Driver assembly: download the `playwright-core` npm tarball plus a pinned
+// Node.js binary and lay them out exactly like the discontinued prebuilt zip
+// (`<dir>/node[.exe]` + `<dir>/package/cli.js`), so the runtime launch path
+// is unchanged (see ADR 0006).
+//
+// `include!`d by `build.rs` and the cli binary — the two places that acquire
+// a driver. Effectful (ureq / zip / flate2 / tar); the pure mapping lives in
+// `driver_urls.rs`, included below, and is unit-tested from the lib suite.
+
+include!("driver_urls.rs");
+
+/// Downloads and assembles the driver into `driver_dir` for a Playwright
+/// `platform` identifier (e.g. `mac-arm64`).
+///
+/// Assembles into a sibling temp directory and renames into place, so an
+/// interrupted run can't leave a half-populated `driver_dir` that a later
+/// exists()-check mistakes for a complete driver. Errors name the URL or
+/// archive entry that failed, so an upstream move is a one-line diagnosis.
+#[allow(dead_code)]
+fn assemble_driver(
+    driver_dir: &std::path::Path,
+    driver_version: &str,
+    platform: &str,
+) -> std::io::Result<()> {
+    use std::io;
+
+    let triple = node_triple(platform).ok_or_else(|| {
+        io::Error::other(format!("unsupported driver platform: {platform}"))
+    })?;
+
+    let parent = driver_dir
+        .parent()
+        .ok_or_else(|| io::Error::other("driver dir has no parent"))?;
+    std::fs::create_dir_all(parent)?;
+
+    // Temp dir next to the target so the final rename stays on one filesystem.
+    let tmp = parent.join(format!(
+        ".{}.partial-{}",
+        driver_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("driver"),
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir_all(&tmp)?;
+
+    let result = (|| {
+        extract_npm_package(&http_get(&npm_core_url(driver_version))?, &tmp)?;
+        extract_node_binary(
+            &http_get(&node_archive_url(NODE_VERSION, triple))?,
+            NODE_VERSION,
+            triple,
+            &tmp,
+        )?;
+
+        // The layout contract the runtime launch path depends on.
+        let node_name = if is_windows_platform(platform) {
+            "node.exe"
+        } else {
+            "node"
+        };
+        for required in [tmp.join(node_name), tmp.join("package").join("cli.js")] {
+            if !required.exists() {
+                return Err(io::Error::other(format!(
+                    "assembled driver is missing {}",
+                    required.display()
+                )));
+            }
+        }
+        Ok(())
+    })();
+
+    if let Err(e) = result {
+        let _ = std::fs::remove_dir_all(&tmp);
+        return Err(e);
+    }
+
+    // A concurrent run may have completed first; its result is equally good.
+    if driver_dir.exists() {
+        let _ = std::fs::remove_dir_all(&tmp);
+        return Ok(());
+    }
+    std::fs::rename(&tmp, driver_dir)
+}
+
+/// GET `url` fully into memory (driver artifacts are tens of MB; ureq's
+/// default 10 MB body cap is lifted). Errors carry the URL.
+#[allow(dead_code)]
+fn http_get(url: &str) -> std::io::Result<Vec<u8>> {
+    use std::io;
+
+    let mut response = ureq::get(url)
+        .call()
+        .map_err(|e| io::Error::other(format!("download of {url} failed: {e}")))?;
+    let status = response.status().as_u16();
+    if !(200..300).contains(&status) {
+        return Err(io::Error::other(format!(
+            "download of {url} failed with status {status}"
+        )));
+    }
+    response
+        .body_mut()
+        .with_config()
+        .limit(u64::MAX)
+        .read_to_vec()
+        .map_err(|e| io::Error::other(format!("reading {url} failed: {e}")))
+}
+
+/// Extracts the npm tarball's `package/` subtree into `dest/package/`.
+#[allow(dead_code)]
+fn extract_npm_package(tgz: &[u8], dest: &std::path::Path) -> std::io::Result<()> {
+    use std::io;
+
+    let gz = flate2::read::GzDecoder::new(tgz);
+    let mut archive = tar::Archive::new(gz);
+    let mut entries = 0usize;
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        if entry.path()?.starts_with("package") {
+            // unpack_in guards against path traversal outside `dest`.
+            entry.unpack_in(dest)?;
+            entries += 1;
+        }
+    }
+    if entries == 0 {
+        return Err(io::Error::other(
+            "npm tarball contained no package/ entries",
+        ));
+    }
+    Ok(())
+}
+
+/// Extracts the `node` executable (plus Node's LICENSE) out of the Node dist
+/// archive into `dest/node[.exe]`, matching the old bundle layout.
+#[allow(dead_code)]
+fn extract_node_binary(
+    archive_bytes: &[u8],
+    node_version: &str,
+    triple: &str,
+    dest: &std::path::Path,
+) -> std::io::Result<()> {
+    use std::io;
+    use std::io::Read;
+
+    let exe_inner = node_archive_exe_path(node_version, triple);
+    let license_inner = format!("node-v{node_version}-{triple}/LICENSE");
+
+    let mut found_exe = false;
+    if triple.starts_with("win-") {
+        let cursor = io::Cursor::new(archive_bytes.to_vec());
+        let mut archive = zip::ZipArchive::new(cursor)
+            .map_err(|e| io::Error::other(format!("Node archive is not a valid zip: {e}")))?;
+        for i in 0..archive.len() {
+            let mut file = archive
+                .by_index(i)
+                .map_err(|e| io::Error::other(format!("zip read failed: {e}")))?;
+            let name = file.name().to_string();
+            let out = if name == exe_inner {
+                found_exe = true;
+                dest.join("node.exe")
+            } else if name == license_inner {
+                dest.join("LICENSE")
+            } else {
+                continue;
+            };
+            let mut bytes = Vec::new();
+            file.read_to_end(&mut bytes)?;
+            std::fs::write(&out, bytes)?;
+        }
+    } else {
+        let gz = flate2::read::GzDecoder::new(archive_bytes);
+        let mut archive = tar::Archive::new(gz);
+        for entry in archive.entries()? {
+            let mut entry = entry?;
+            let path = entry.path()?.to_path_buf();
+            let out = if path == std::path::Path::new(&exe_inner) {
+                found_exe = true;
+                dest.join("node")
+            } else if path == std::path::Path::new(&license_inner) {
+                dest.join("LICENSE")
+            } else {
+                continue;
+            };
+            entry.unpack(&out)?;
+            #[cfg(unix)]
+            if out.ends_with("node") {
+                use std::os::unix::fs::PermissionsExt;
+                let mut perms = std::fs::metadata(&out)?.permissions();
+                perms.set_mode(0o755);
+                std::fs::set_permissions(&out, perms)?;
+            }
+        }
+    }
+
+    if !found_exe {
+        return Err(io::Error::other(format!(
+            "Node archive did not contain {exe_inner}"
+        )));
+    }
+    Ok(())
+}

--- a/crates/playwright/src/build_support/driver_urls.rs
+++ b/crates/playwright/src/build_support/driver_urls.rs
@@ -1,0 +1,146 @@
+// Pure platform-mapping and URL construction for driver acquisition.
+//
+// The prebuilt driver zips died with the azureedge CDN, so the driver is
+// assembled from two artifacts: the `playwright-core` npm tarball and a
+// pinned Node.js binary (see ADR 0006). This file is std-only so it can be
+// `include!`d by `build.rs` and the cli binary, and unit-tested from the
+// library suite without pulling the download deps into the lib.
+
+/// Node.js runtime bundled with the driver. Must match the upstream
+/// Playwright release's own pin for `PLAYWRIGHT_VERSION` (playwright-python
+/// commits it as `NODE_VERSION` at the matching tag).
+#[allow(dead_code)]
+const NODE_VERSION: &str = "24.17.0";
+
+/// Playwright platform identifier for an (os, arch) pair, e.g.
+/// `("macos", "aarch64")` → `mac-arm64`. `None` for unsupported pairs.
+#[allow(dead_code)]
+fn playwright_platform(os: &str, arch: &str) -> Option<&'static str> {
+    match (os, arch) {
+        ("macos", "x86_64") => Some("mac"),
+        ("macos", "aarch64") => Some("mac-arm64"),
+        ("linux", "x86_64") => Some("linux"),
+        ("linux", "aarch64") => Some("linux-arm64"),
+        ("windows", "x86_64") => Some("win32_x64"),
+        ("windows", "aarch64") => Some("win32_arm64"),
+        _ => None,
+    }
+}
+
+/// Node dist triple for a Playwright platform identifier, e.g.
+/// `mac-arm64` → `darwin-arm64` (Node names platforms differently).
+#[allow(dead_code)]
+fn node_triple(playwright_platform: &str) -> Option<&'static str> {
+    match playwright_platform {
+        "mac" => Some("darwin-x64"),
+        "mac-arm64" => Some("darwin-arm64"),
+        "linux" => Some("linux-x64"),
+        "linux-arm64" => Some("linux-arm64"),
+        "win32_x64" => Some("win-x64"),
+        "win32_arm64" => Some("win-arm64"),
+        _ => None,
+    }
+}
+
+/// Whether a Playwright platform identifier is a Windows target (Node ships
+/// a `.zip` with `node.exe` there; `.tar.gz` with `bin/node` elsewhere).
+#[allow(dead_code)]
+fn is_windows_platform(playwright_platform: &str) -> bool {
+    playwright_platform.starts_with("win32")
+}
+
+/// npm registry URL of the `playwright-core` tarball for a driver version.
+#[allow(dead_code)]
+fn npm_core_url(driver_version: &str) -> String {
+    format!("https://registry.npmjs.org/playwright-core/-/playwright-core-{driver_version}.tgz")
+}
+
+/// nodejs.org URL of the Node binary archive for a Node dist triple.
+#[allow(dead_code)]
+fn node_archive_url(node_version: &str, triple: &str) -> String {
+    let ext = if triple.starts_with("win-") {
+        "zip"
+    } else {
+        "tar.gz"
+    };
+    format!("https://nodejs.org/dist/v{node_version}/node-v{node_version}-{triple}.{ext}")
+}
+
+/// Path of the `node` executable inside the Node dist archive.
+#[allow(dead_code)]
+fn node_archive_exe_path(node_version: &str, triple: &str) -> String {
+    if triple.starts_with("win-") {
+        format!("node-v{node_version}-{triple}/node.exe")
+    } else {
+        format!("node-v{node_version}-{triple}/bin/node")
+    }
+}
+
+#[cfg(test)]
+mod driver_urls_tests {
+    use super::*;
+
+    const ALL: [(&str, &str, &str, &str); 6] = [
+        ("macos", "x86_64", "mac", "darwin-x64"),
+        ("macos", "aarch64", "mac-arm64", "darwin-arm64"),
+        ("linux", "x86_64", "linux", "linux-x64"),
+        ("linux", "aarch64", "linux-arm64", "linux-arm64"),
+        ("windows", "x86_64", "win32_x64", "win-x64"),
+        ("windows", "aarch64", "win32_arm64", "win-arm64"),
+    ];
+
+    #[test]
+    fn every_supported_target_maps_to_platform_and_triple() {
+        for (os, arch, platform, triple) in ALL {
+            assert_eq!(playwright_platform(os, arch), Some(platform));
+            assert_eq!(node_triple(platform), Some(triple));
+        }
+        assert_eq!(playwright_platform("freebsd", "x86_64"), None);
+        assert_eq!(node_triple("solaris"), None);
+    }
+
+    #[test]
+    fn windows_platforms_are_detected() {
+        assert!(is_windows_platform("win32_x64"));
+        assert!(is_windows_platform("win32_arm64"));
+        assert!(!is_windows_platform("mac-arm64"));
+        assert!(!is_windows_platform("linux"));
+    }
+
+    #[test]
+    fn npm_url_matches_registry_scheme() {
+        assert_eq!(
+            npm_core_url("1.61.1"),
+            "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz"
+        );
+    }
+
+    #[test]
+    fn node_urls_and_exe_paths_per_family() {
+        assert_eq!(
+            node_archive_url("24.17.0", "darwin-arm64"),
+            "https://nodejs.org/dist/v24.17.0/node-v24.17.0-darwin-arm64.tar.gz"
+        );
+        assert_eq!(
+            node_archive_url("24.17.0", "win-x64"),
+            "https://nodejs.org/dist/v24.17.0/node-v24.17.0-win-x64.zip"
+        );
+        assert_eq!(
+            node_archive_exe_path("24.17.0", "linux-x64"),
+            "node-v24.17.0-linux-x64/bin/node"
+        );
+        assert_eq!(
+            node_archive_exe_path("24.17.0", "win-arm64"),
+            "node-v24.17.0-win-arm64/node.exe"
+        );
+    }
+
+    #[test]
+    fn node_pin_is_a_bare_semver() {
+        // The xtask drift guard and the nodejs.org URL scheme both assume a
+        // bare MAJOR.MINOR.PATCH (no leading 'v').
+        let parts: Vec<&str> = NODE_VERSION.split('.').collect();
+        assert_eq!(parts.len(), 3, "NODE_VERSION must be MAJOR.MINOR.PATCH");
+        assert!(parts.iter().all(|p| p.parse::<u32>().is_ok()));
+    }
+}

--- a/crates/playwright/src/lib.rs
+++ b/crates/playwright/src/lib.rs
@@ -402,3 +402,11 @@ pub use server::driver::{install_browsers, install_browsers_with_deps};
 // available can opt out.
 #[cfg(feature = "macros")]
 pub use playwright_rs_macros::locator;
+
+// The pure driver-acquisition mapping (platform → Node triple, download URLs)
+// that build.rs and the cli binary `include!`. std-only, so compiling it into
+// the lib's test suite costs nothing at runtime and keeps its unit tests in
+// the always-run `cargo nextest` pass.
+#[cfg(test)]
+#[path = "build_support/driver_urls.rs"]
+mod driver_urls;

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 # xtask is `publish = false`, so the version constraint is purely
 # bookkeeping for cargo-deny — the path resolution wins.
-playwright-rs = { path = "../playwright", version = "0.14.0" }
+playwright-rs = { path = "../playwright", version = "0.14.1" }
 tokio = { workspace = true }
 anyhow = { workspace = true }
 clap = { version = "4", features = ["derive"] }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -93,6 +93,12 @@ user-id = 6743 # Ed Page (epage)
 start = "2023-04-13"
 end = "2027-05-16"
 
+[[trusted.filetime]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-04-23"
+end = "2027-07-11"
+
 [[trusted.flate2]]
 criteria = "safe-to-deploy"
 user-id = 980 # Sebastian Thiel (Byron)
@@ -212,6 +218,12 @@ criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-03-01"
 end = "2027-05-23"
+
+[[trusted.tar]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-03-04"
+end = "2027-07-11"
 
 [[trusted.target-triple]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -254,7 +254,7 @@ version = "0.2.17"
 criteria = "safe-to-deploy"
 
 [[exemptions.playwright-rs]]
-version = "0.13.0"
+version = "0.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.playwright-rs-macros]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -2,8 +2,8 @@
 # cargo-vet imports lock
 
 [[unpublished.playwright-rs]]
-version = "0.14.0"
-audited_as = "0.13.0"
+version = "0.14.1"
+audited_as = "0.14.0"
 
 [[publisher.aho-corasick]]
 version = "1.1.4"
@@ -48,8 +48,8 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.anyhow]]
-version = "1.0.102"
-when = "2026-02-20"
+version = "1.0.103"
+when = "2026-06-25"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -109,6 +109,13 @@ when = "2026-03-13"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
+
+[[publisher.filetime]]
+version = "0.2.29"
+when = "2026-05-12"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
 
 [[publisher.flate2]]
 version = "1.1.9"
@@ -249,6 +256,13 @@ when = "2026-02-20"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
+
+[[publisher.tar]]
+version = "0.4.45"
+when = "2026-03-19"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
 
 [[publisher.target-triple]]
 version = "1.0.0"
@@ -652,6 +666,12 @@ criteria = "safe-to-deploy"
 delta = "0.9.15 -> 0.9.18"
 notes = "Nontrivial update but mostly around dependencies and how `unsafe` code is managed. Everything looks the same shape as before."
 
+[[audits.bytecode-alliance.audits.crossbeam-epoch]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.18 -> 0.9.20"
+notes = "Minor updates, nothing out of place."
+
 [[audits.bytecode-alliance.audits.errno]]
 who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"
@@ -909,6 +929,12 @@ criteria = "safe-to-deploy"
 delta = "1.13.2 -> 1.14.0"
 notes = "Minor new feature, nothing out of the ordinary."
 
+[[audits.bytecode-alliance.audits.tar]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.45 -> 0.4.46"
+notes = "Nothing awry, no changes to unsafe or such."
+
 [[audits.bytecode-alliance.audits.thread_local]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -989,6 +1015,24 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.243.0 -> 0.244.0"
 notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.audits.xattr]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+version = "1.2.0"
+notes = "This crate contains `unsafe` calls to libc `extattr_*` functions as one would expect from the crate's purpose."
+
+[[audits.bytecode-alliance.audits.xattr]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+delta = "1.2.0 -> 1.3.1"
+notes = "Minor changes to MacOS-specific code."
+
+[[audits.bytecode-alliance.audits.xattr]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "1.3.1 -> 1.6.1"
+notes = "Refactorings and minor updates, nothing out of place."
 
 [[audits.bytecode-alliance.audits.zeroize]]
 who = "Pat Hickey <p.hickey@f5.com>"


### PR DESCRIPTION
CI-validation vehicle for the v0.14.1 patch release — **never merge this**: the base shows main's full divergence from the 0.14.x line. The release ships by tagging `v0.14.1` on the branch once checks are green; this PR gets closed after.

Backports the driver-acquisition fix (assemble from npm playwright-core + pinned Node, ADR 0006) to the 0.14.x line with the driver staying at 1.60.0. Fixes #116's root cause for `= "0.14"` consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)