### PR TITLE
Version the skill on both channels and hold it to the crate's capabilities

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "playwright-rs",
       "source": "./",
-      "description": "Procedural reference for writing Rust browser automation with playwright-rs: object model, the locator!() macro, builder options, auto-wait semantics, and trace capture.",
+      "description": "Procedural reference for writing Rust browser automation with playwright-rs: adding the crate and installing its browsers, object model, the locator!() macro, builder options, auto-wait semantics, and trace capture.",
       "homepage": "https://playwright-rust.dev",
       "license": "Apache-2.0"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright-rs",
-  "version": "0.2.1",
-  "description": "Procedural reference for writing Rust browser automation with playwright-rs: object model, the locator!() macro, builder options, auto-wait semantics, and trace capture.",
+  "version": "0.3.0",
+  "description": "Procedural reference for writing Rust browser automation with playwright-rs: adding the crate and installing its browsers, object model, the locator!() macro, builder options, auto-wait semantics, and trace capture.",
   "author": {
     "name": "Paul Adamson",
     "email": "paul@seekingeta.ai"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,7 +93,7 @@ repos:
         pass_filenames: false
         # Run when the snippet sources change OR when the crate API
         # surface changes.
-        files: (docs/agent/|skills/playwright-rs-usage/|crates/playwright/src/|crates/playwright-rs-macros/src/|crates/xtask/src/)
+        files: (docs/agent/|skills/playwright-rs-usage/|crates/playwright/src/|crates/playwright/Cargo\.toml|crates/playwright-rs-macros/src/|crates/xtask/src/)
 
       # 5b. Verify every source/CI reference to the bundled Playwright
       # version matches build.rs PLAYWRIGHT_VERSION (README excluded —

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -9,7 +9,10 @@
 //!   from `docs/agent/CLAUDE_SNIPPET.md` and
 //!   `skills/playwright-rs-usage/SKILL.md`, then runs
 //!   `cargo check` against them so they can't silently drift from the
-//!   crate API.
+//!   crate API. Then asserts the shipped skill still *names* every
+//!   API-gating cargo feature and browser engine, so a capability
+//!   can't ship undocumented — the compile check only proves the code
+//!   the skill does show is valid, never that something is missing.
 //! - `verify-site-snippets` — wraps each `crates/site/snippets/*.rs`
 //!   fragment shown on the landing page in a binding prelude and runs
 //!   `cargo check`, so the site can't advertise code that doesn't
@@ -169,8 +172,11 @@ fn verify_agent_docs() -> Result<()> {
     }
 
     if blocks.is_empty() {
-        println!("verify-agent-docs: no `rust,no_run` blocks found — nothing to check");
-        return Ok(());
+        // Still run the capability guard: it reads the skill directly and
+        // must not be skipped just because the prose currently carries no
+        // compilable block.
+        println!("verify-agent-docs: no `rust,no_run` blocks found — nothing to compile");
+        return verify_skill_covers_capabilities(&workspace_root);
     }
 
     let check_dir = workspace_root.join("target/agent-docs-verify");
@@ -234,7 +240,143 @@ playwright-rs = {{ path = {playwright_path:?} }}
         "verify-agent-docs: {} block(s) compile cleanly against playwright-rs",
         blocks.len()
     );
+
+    verify_skill_covers_capabilities(&workspace_root)?;
     Ok(())
+}
+
+/// Cargo features that gate build/transport configuration rather than API
+/// surface. An agent writing test code never picks between these, so the
+/// skill is not required to name them.
+///
+/// This list is the reason the check is worth having: anything *not* named
+/// here must be documented, so a new capability cannot ship without the
+/// skill mentioning it. Adding a feature here is a deliberate act, not a
+/// default.
+const NON_API_FEATURES: &[&str] = &[
+    "native-tls",
+    "rustls-tls-native-roots",
+    "rustls-tls-webpki-roots",
+    "ring",
+    "aws-lc",
+];
+
+/// Assert the shipped skill still names every capability the crate exposes.
+///
+/// The compile check above proves the skill's code is *valid*; it says
+/// nothing about what the skill left out. This is the other half: each
+/// API-gating cargo feature and each browser engine must appear somewhere in
+/// the text, so shipping one without documenting it fails the build.
+///
+/// Neither half checks that the surrounding prose is *accurate*. That
+/// residue is real and is stated in the skill itself.
+fn verify_skill_covers_capabilities(workspace_root: &Path) -> Result<()> {
+    let skill_path = workspace_root.join("skills/playwright-rs-usage/SKILL.md");
+    let skill = std::fs::read_to_string(&skill_path)
+        .with_context(|| format!("read {}", skill_path.display()))?;
+
+    let manifest_path = workspace_root.join("crates/playwright/Cargo.toml");
+    let manifest = std::fs::read_to_string(&manifest_path)
+        .with_context(|| format!("read {}", manifest_path.display()))?;
+
+    let mut missing: Vec<String> = Vec::new();
+
+    // Both extractors are text scrapers, so they fail open: if a rename or a
+    // rustfmt rewrap stops them matching, an empty list would sail through
+    // and print success. Refuse to pass on nothing found.
+    let features = feature_names(&manifest);
+    if features.is_empty() {
+        bail!(
+            "verify-agent-docs: found no features in {} -- the [features] parser has drifted, \
+             not the docs.",
+            manifest_path.display()
+        );
+    }
+
+    for feature in features {
+        if feature == "default" || NON_API_FEATURES.contains(&feature.as_str()) {
+            continue;
+        }
+        if !mentions(&skill, &feature) {
+            missing.push(format!("cargo feature `{feature}`"));
+        }
+    }
+
+    let playwright_rs = workspace_root.join("crates/playwright/src/protocol/playwright.rs");
+    let engines_src = std::fs::read_to_string(&playwright_rs)
+        .with_context(|| format!("read {}", playwright_rs.display()))?;
+    let engines = browser_engines(&engines_src);
+    if engines.is_empty() {
+        bail!(
+            "verify-agent-docs: found no browser engines in {} -- the accessor parser has \
+             drifted, not the docs.",
+            playwright_rs.display()
+        );
+    }
+    for engine in engines {
+        if !mentions(&skill, &engine) {
+            missing.push(format!("browser engine `{engine}`"));
+        }
+    }
+
+    if !missing.is_empty() {
+        bail!(
+            "verify-agent-docs: {} shipped capability/capabilities are absent from {}:\n  {}\n\
+             Document them, or -- for a build/transport knob an agent never chooses -- \
+             add the feature to NON_API_FEATURES in crates/xtask/src/main.rs.",
+            missing.len(),
+            skill_path
+                .strip_prefix(workspace_root)
+                .unwrap_or(&skill_path)
+                .display(),
+            missing.join("\n  "),
+        );
+    }
+
+    println!("verify-agent-docs: skill names every API-gating feature and browser engine");
+    Ok(())
+}
+
+/// Whether `needle` appears in `haystack` as a whole token.
+///
+/// A plain `contains` is wrong here: the `cli` feature would match "click"
+/// and "client" and silently pass, which it did on the first run of this
+/// check. Identifier characters on either side disqualify a hit.
+fn mentions(haystack: &str, needle: &str) -> bool {
+    let is_ident = |c: char| c.is_alphanumeric() || c == '-' || c == '_';
+    haystack.match_indices(needle).any(|(i, m)| {
+        let before = haystack[..i].chars().next_back();
+        let after = haystack[i + m.len()..].chars().next();
+        !before.is_some_and(is_ident) && !after.is_some_and(is_ident)
+    })
+}
+
+/// Feature names from a manifest's `[features]` table.
+fn feature_names(manifest: &str) -> Vec<String> {
+    manifest
+        .lines()
+        .skip_while(|l| l.trim() != "[features]")
+        .skip(1)
+        .take_while(|l| !l.trim_start().starts_with('['))
+        .filter_map(|l| l.split_once('=').map(|(name, _)| name.trim()))
+        .filter(|name| !name.is_empty() && !name.starts_with('#'))
+        .map(str::to_string)
+        .collect()
+}
+
+/// Browser-engine accessors on `Playwright` (`pub fn x(&self) -> &BrowserType`).
+fn browser_engines(source: &str) -> Vec<String> {
+    source
+        .lines()
+        .filter_map(|l| {
+            let l = l.trim();
+            let rest = l.strip_prefix("pub fn ")?;
+            if !rest.contains("-> &BrowserType") {
+                return None;
+            }
+            rest.split_once('(').map(|(name, _)| name.to_string())
+        })
+        .collect()
 }
 
 fn verify_site_snippets() -> Result<()> {
@@ -841,5 +983,84 @@ mod changelog_link_tests {
             let problems = changelog_link_problems(&content, prefix);
             assert!(problems.is_empty(), "{rel}:\n{}", problems.join("\n"));
         }
+    }
+}
+
+#[cfg(test)]
+mod skill_coverage_tests {
+    use super::*;
+
+    const MANIFEST: &str = "\
+[package]
+name = \"playwright-rs\"
+
+[features]
+default = [\"native-tls\", \"macros\", \"ring\"]
+native-tls = [\"tokio-tungstenite/native-tls\"]
+# retired-feature = [\"dep:gone\"]
+ = \"malformed\"
+screenshot-diff = [\"dep:image\"]
+cli = [
+    \"dep:clap\",
+    \"dep:ureq\",
+]
+
+[dependencies]
+anyhow = \"1\"
+";
+
+    #[test]
+    fn feature_names_reads_the_table_and_stops_at_the_next_section() {
+        assert_eq!(
+            feature_names(MANIFEST),
+            vec!["default", "native-tls", "screenshot-diff", "cli"],
+            "multi-line feature arrays must not leak their entries, \
+             [dependencies] must not be read as features, and a commented-out \
+             or nameless line must not become a feature the skill has to document"
+        );
+    }
+
+    #[test]
+    fn feature_names_is_empty_without_a_features_table() {
+        assert!(feature_names("[package]\nname = \"x\"\n").is_empty());
+    }
+
+    #[test]
+    fn browser_engines_finds_accessors_by_return_type() {
+        let src = "\
+    pub fn chromium(&self) -> &BrowserType {
+    pub fn firefox(&self) -> &BrowserType {
+    pub fn chromium_sandbox(mut self, enabled: bool) -> Self {
+    fn private_engine(&self) -> &BrowserType {
+";
+        assert_eq!(
+            browser_engines(src),
+            vec!["chromium", "firefox"],
+            "only public accessors returning &BrowserType count"
+        );
+    }
+
+    #[test]
+    fn mentions_requires_a_whole_token() {
+        // The bug this guards: `contains` let the `cli` feature match
+        // "click"/"client" in the prose, so it passed while undocumented.
+        assert!(!mentions("use page.click() on the client", "cli"));
+        assert!(mentions("the `cli` feature builds an installer", "cli"));
+        assert!(mentions("cli", "cli"));
+    }
+
+    #[test]
+    fn mentions_does_not_treat_a_hyphen_as_a_boundary() {
+        // `screenshot-diff` must not be satisfied by a bare "screenshot",
+        // nor "ring" by "rustls-tls-native-roots".
+        assert!(!mentions(
+            "take a screenshot of the page",
+            "screenshot-diff"
+        ));
+        assert!(mentions(
+            "enable `screenshot-diff` for baselines",
+            "screenshot-diff"
+        ));
+        assert!(!mentions("aws-lc-rs is the backend", "aws-lc"));
     }
 }

--- a/scripts/check-plugin-version-bumped.sh
+++ b/scripts/check-plugin-version-bumped.sh
@@ -35,3 +35,35 @@ if [ "$old" = "$new" ]; then
   echo "Bump the version so installed consumers see the update." >&2
   exit 1
 fi
+
+# The same skill reaches consumers through two channels. /plugin gates on
+# plugin.json's version; the Agent Skills format has no version concept and
+# just re-pulls, so metadata.version in the frontmatter is the only version a
+# non-plugin consumer can read. They have to agree or the two channels
+# disagree about what is installed.
+skill=skills/playwright-rs-usage/SKILL.md
+
+skill_version=$(git show ":$skill" 2>/dev/null | python3 -c '
+import re, sys
+text = sys.stdin.read()
+m = re.match(r"^---\n(.*?)\n---\n", text, re.S)
+if not m:
+    sys.exit("no frontmatter")
+m = re.search(r"^metadata:\n(?:[ \t]+.*\n)*?[ \t]+version:[ \t]*\"?([^\"\n]+)\"?", m.group(1), re.M)
+print(m.group(1).strip() if m else "")
+') || {
+  echo "plugin version guard: could not read frontmatter from $skill." >&2
+  exit 1
+}
+
+if [ -z "$skill_version" ]; then
+  echo "plugin version guard: $skill has no metadata.version." >&2
+  echo "Add one matching $manifest ($new) -- it is the only version a" >&2
+  echo "consumer installing outside /plugin can see." >&2
+  exit 1
+fi
+if [ "$skill_version" != "$new" ]; then
+  echo "plugin version guard: $manifest is $new but $skill says $skill_version." >&2
+  echo "Move them together." >&2
+  exit 1
+fi

--- a/skills/playwright-rs-usage/SKILL.md
+++ b/skills/playwright-rs-usage/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: playwright-rs-usage
-description: Procedural reference for using playwright-rs in Rust browser-automation code — object model (Browser/Context/Page/Locator), the `locator!()` macro, builder pattern for options, auto-wait semantics, and how to capture / inspect traces for failure diagnosis. Use when writing tests or scripts with playwright-rs as a dependency. Loaded automatically when the current repo has playwright-rs in its Cargo.toml; can also be copied into downstream projects at `.claude/skills/playwright-rs-usage/`.
+description: Procedural reference for using playwright-rs in Rust browser-automation code — object model (Browser/Context/Page/Locator), the `locator!()` macro, builder pattern for options, auto-wait semantics, adding the crate and installing its browsers, and how to capture / inspect traces for failure diagnosis. Use when writing tests or scripts with playwright-rs as a dependency. Loaded automatically when the current repo has playwright-rs in its Cargo.toml.
+license: Apache-2.0
+metadata:
+  version: "0.3.0"
 ---
 
 # Using playwright-rs
@@ -20,6 +23,62 @@ reference. The one Rust code block below is compile-checked by
 `cargo xtask verify-agent-docs`; the rest is prose that ages well
 because it talks in concepts (auto-wait, builder pattern) rather
 than specific method names.
+
+## Before any of this works
+
+Two things, and the second one is the one that surprises people.
+
+**The crate.** `playwright-rs` in `[dependencies]`, or `[dev-dependencies]`
+if it is test-only, alongside `tokio` with the `full` feature. Defaults are
+`native-tls`, `macros` and `ring`: transport, the `locator!()` macro, and
+the crypto backend respectively.
+
+Prefer leaving them on. `default-features = false` is only needed to swap
+`ring` for `aws-lc`, and it drops all three, so the replacements have to be
+listed back explicitly or `locator!()` disappears and no TLS transport
+remains:
+
+```toml
+playwright-rs = { version = "0.16", default-features = false, features = [
+    "aws-lc",
+    "native-tls",
+    "macros",
+] }
+```
+
+Two capabilities are opt-in and off unless asked for. `screenshot-diff`
+turns on pixel-diff screenshot assertions, so reach for it when the task
+calls for comparing a rendering against a baseline rather than asserting on
+the DOM. `cli` builds an installer binary for use outside a Cargo project;
+inside one, prefer the example below, because `cargo install` compiles a
+second copy of the crate that then has to be kept in sync with the
+project's lockfile.
+
+**The browsers, which are a separate install and are required.** A fresh
+checkout that only adds the dependency will fail at launch. The crate
+bundles one pinned Playwright driver and each driver expects matching
+browser builds, so install them *through the crate* rather than through a
+global `npx playwright install`. That way the browser version rides
+`Cargo.lock` and cannot drift from the driver. Copy
+[`examples/install-browsers.rs`](https://github.com/padamson/playwright-rust/blob/main/crates/playwright/examples/install-browsers.rs)
+into the project's `examples/` and run it once:
+
+```bash
+cargo run --example install-browsers                        # all
+cargo run --example install-browsers -- chromium firefox    # or a subset
+```
+
+The same line belongs in CI before the test step. Never pin a Playwright
+version in a workflow or a `package.json`: dependabot cannot see the
+former and bumps the latter on npm's cadence rather than the crate's, and
+either way the driver and browsers stop matching. The driver ships its own
+Node runtime, so no `setup-node` step is needed. In a setup script or
+Dockerfile, call
+[`install_browsers`](https://docs.rs/playwright-rs/latest/playwright_rs/fn.install_browsers.html)
+directly instead.
+
+On Linux the driver also installs the system libraries the browsers need,
+and may invoke sudo to do it.
 
 ## Object model
 


### PR DESCRIPTION
The skill reaches consumers two ways. `/plugin update` gates on
`plugin.json`'s version, while an install through the Agent Skills CLI can
only see frontmatter, so `metadata.version` is the only version most
consumers can read. The existing version guard now requires the two to move
together, and rejects a skill with no `metadata.version` at all.

`verify-agent-docs` only ever proved that the code the skill *shows*
compiles. It could not notice something absent. It now also asserts every
API-gating cargo feature and every browser engine is named somewhere in the
text, with an explicit allowlist for transport knobs an agent never chooses,
so a new feature defaults to must-be-documented rather than silently
uncovered.

Running it found three real gaps: `screenshot-diff` and `cli` were
undocumented, and the skill assumed the crate was already a dependency and
its browsers already installed. Browser installation in particular is
required, separate, and the thing a fresh project trips over first, so it now
leads the skill.

Both extractors are text scrapers and previously failed open: an empty result
printed success. They now bail, and say whether the parser or the docs
drifted, since those want opposite fixes. The capability guard also runs when
there is no compilable block, rather than being skipped by the early return.

The pure helpers carry unit tests and were mutation-tested (23/23 caught).
Two bugs surfaced that reading had missed: a substring match let `cli` be
satisfied by "click", and the feature-table filter would have read a
commented-out line containing `=` as a real feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)