### PR TITLE
Make the skill the single agent-facing artifact

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-rs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Procedural reference for writing Rust browser automation with playwright-rs: adding the crate and installing its browsers, object model, the locator!() macro, builder options, auto-wait semantics, and trace capture.",
   "author": {
     "name": "Paul Adamson",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,13 +111,21 @@ Just-in-time philosophy — write the right thing in the right file:
    docs (`See: <https://playwright.dev/...>`), errors section, and any
    Rust-specific behavior notes. Examples go in module-level doctests
    per the doctest-conventions skill, not on individual functions.
-6. **`docs/agent/`** — guidance distributed to downstream Rust
-   projects that consume this crate from a Claude Code / agent
-   workflow. `CLAUDE_SNIPPET.md` is the copy-paste version;
-   `skills/playwright-rs-usage/SKILL.md` is the canonical skill, which
-   downstream users install with `npx skills add padamson/playwright-rust`
-   or as a Claude Code plugin. Keep both in sync — the snippet is the
-   short-form version of the skill.
+6. **`skills/playwright-rs-usage/SKILL.md`** — the single agent-facing
+   artifact distributed to downstream Rust projects. Installed with
+   `npx skills add padamson/playwright-rust` or as a Claude Code plugin.
+   `docs/agent/CLAUDE_SNIPPET.md` is now only a pointer to it: it used
+   to be a hand-synced copy-paste duplicate, which is exactly the shape
+   that goes stale and then teaches the old API. There is no second
+   copy to keep in sync any more, so don't reintroduce one.
+
+   Two build gates hold the skill to the code, and they check different
+   things. `cargo xtask verify-agent-docs` compiles its `rust,no_run`
+   blocks against the real crate, catching code that stopped working;
+   it then asserts the skill *names* every API-gating cargo feature and
+   browser engine, catching a capability that shipped undocumented.
+   Neither checks that the surrounding prose is accurate. That residue
+   is real, and the skill says so itself.
 
    The same skill is also installable as a Claude Code plugin:
    [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/padamson/playwright-rust/actions/workflows/test.yml/badge.svg)](https://github.com/padamson/playwright-rust/actions/workflows/test.yml)
 [![License](https://img.shields.io/crates/l/playwright-rs)](LICENSE)
 [![Playwright](https://img.shields.io/badge/Playwright-1.62.1-45ba4b)](https://playwright.dev)
+[![skills.sh](https://skills.sh/b/padamson/playwright-rust)](https://skills.sh/padamson/playwright-rust)
 
 > Rust language bindings for [Microsoft Playwright](https://playwright.dev) — the industry standard for cross-browser end-to-end testing.
 
@@ -333,12 +334,22 @@ for a runnable end-to-end example. Open the resulting `trace.zip` at
 
 ## Using with Claude Code / AI agents
 
-If you're writing playwright-rs tests with Claude Code or another
-coding agent, this repo ships the API model in three forms so the
-agent isn't guessing from generic Playwright knowledge.
+This repo ships an [Agent Skill](https://agentskills.io) so your agent
+writes against this crate's actual API model instead of guessing from
+generic Playwright knowledge. It covers adding the dependency and
+installing browsers, the object model, the builder and `locator!()`
+conventions, auto-wait semantics, and capturing a trace when something
+fails.
 
-The quickest is to install it as a Claude Code plugin, which tracks
-this repo and updates in place:
+```bash
+npx skills add padamson/playwright-rust
+```
+
+Works with [Claude Code](https://claude.ai/code),
+[Codex](https://openai.com/codex/), [Cursor](https://cursor.com), and any
+other [compatible agent](https://agentskills.io/clients).
+
+Claude Code can also install it as a plugin, which tracks this repo:
 
 ```bash
 /plugin marketplace add padamson/playwright-rust
@@ -353,22 +364,14 @@ version with both commands, catalog first:
 /plugin update playwright-rs@playwright-rust
 ```
 
-The other two are copied into your downstream project:
-
-- [**`docs/agent/CLAUDE_SNIPPET.md`**](docs/agent/CLAUDE_SNIPPET.md) —
-  a ~50-line section to paste into your project's `CLAUDE.md`. Covers
-  the object model, conventions (builder pattern, `locator!()`,
-  auto-wait), and the trace-on-failure pattern. Zero-friction install:
-  one paste.
-- [**`skills/playwright-rs-usage/`**](skills/playwright-rs-usage/) —
-  the same content in skill form (auto-loads when the trigger
-  description matches the user's request). Install with
-  `npx skills add padamson/playwright-rust`.
-
-Both point back at [docs.rs](https://docs.rs/playwright-rs) and the
-[examples](crates/playwright/examples/) for the API surface itself —
-they're a thin "what to reach for, what to avoid" overlay rather than
-a duplicate of the API reference.
+The skill lives at
+[`skills/playwright-rs-usage/`](skills/playwright-rs-usage/). It points back
+at [docs.rs](https://docs.rs/playwright-rs) and the
+[examples](crates/playwright/examples/) for the API surface itself, being a
+thin "what to reach for, what to avoid" overlay rather than a duplicate of
+the API reference. A build gate keeps it honest: its code compiles against
+the real crate, and it cannot omit a cargo feature or browser engine the
+crate exposes.
 
 ## Star History
 

--- a/crates/playwright/src/lib.rs
+++ b/crates/playwright/src/lib.rs
@@ -63,11 +63,11 @@
 //!
 //! ## For AI coding agents
 //!
-//! If you're using this crate with Claude Code or another coding agent,
-//! see [`docs/agent/`](https://github.com/padamson/playwright-rust/tree/main/docs/agent)
-//! for a copy-paste CLAUDE.md snippet and the
+//! If you're using this crate with a coding agent, install the
 //! [`playwright-rs-usage` skill](https://github.com/padamson/playwright-rust/tree/main/skills/playwright-rs-usage)
-//! you can drop into your project's `.claude/skills/`.
+//! with `npx skills add padamson/playwright-rust`. It works with Claude
+//! Code, Codex, Cursor and other skills-compatible agents, and gives the
+//! agent this crate's API model instead of generic Playwright knowledge.
 //!
 //! # Examples
 //!

--- a/crates/playwright/tests/integration/wait_for_function.rs
+++ b/crates/playwright/tests/integration/wait_for_function.rs
@@ -80,26 +80,38 @@ async fn test_wait_for_function_polling_interval_sees_off_frame_state() {
 async fn test_locator_wait_for_function_receives_the_matched_element() {
     let (_pw, browser, page) = crate::common::setup().await;
 
+    // The flag flips in the same synchronous callback as the state, so any
+    // poll that observes `done` necessarily observes `__flipped` too.
     page.set_content(
         "<div id='target' data-state='pending'>x</div>\
-         <script>setTimeout(() => \
-           document.getElementById('target').dataset.state = 'done', 300);</script>",
+         <script>window.__flipped = false; \
+           setTimeout(() => { \
+             document.getElementById('target').dataset.state = 'done'; \
+             window.__flipped = true; \
+           }, 300);</script>",
         None,
     )
     .await
     .expect("set_content");
 
     // Bare arrow on purpose: a client-side isFunction guess resolves this
-    // vacuously; the elapsed check pins that the wait actually waited.
-    let start = std::time::Instant::now();
+    // vacuously. Asking the page whether the flip had happened pins that the
+    // wait actually waited, without measuring wall-clock here: the timer
+    // starts when set_content runs the script, not when set_content returns,
+    // so a host-side elapsed check silently loses whatever the round trip
+    // cost and fails under load.
     page.locator("#target")
         .wait_for_function("el => el.dataset.state === 'done'", None)
         .await
         .expect("should resolve once the bound element reaches the state");
+
+    let flipped: bool = page
+        .evaluate("() => window.__flipped", None::<&()>)
+        .await
+        .expect("probe the flip flag");
     assert!(
-        start.elapsed() >= std::time::Duration::from_millis(250),
-        "resolved in {:?}, before the 300ms state flip: the expression cannot have run against the element",
-        start.elapsed()
+        flipped,
+        "resolved before the state flip: the expression cannot have run against the element"
     );
 
     browser.close().await.expect("close");

--- a/docs/agent/CLAUDE_SNIPPET.md
+++ b/docs/agent/CLAUDE_SNIPPET.md
@@ -1,111 +1,23 @@
-# Playwright-rs — copy-paste CLAUDE.md snippet
+# Playwright-rs agent guidance
 
-Drop this section into your project's `CLAUDE.md` when you depend on
-[`playwright-rs`](https://crates.io/crates/playwright-rs). It gives the
-coding agent enough of the API model to write idiomatic test code
-instead of guessing from generic Playwright knowledge.
+This used to be a copy-paste section for your project's `CLAUDE.md`, kept
+in sync by hand with the skill it duplicated. Install the skill instead:
 
-Source of truth for the API itself stays on
-[docs.rs](https://docs.rs/playwright-rs) — this snippet is just the
-"what to reach for, what to avoid" overlay.
+```bash
+npx skills add padamson/playwright-rust
+```
 
-For a richer, auto-discovered version of the same guidance, see the
-companion [`playwright-rs-usage` skill](../../skills/playwright-rs-usage/),
-which Claude Code can also install directly:
+It works with Claude Code, Codex, Cursor, and any other
+[compatible agent](https://agentskills.io/clients), and Claude Code can
+take it as a plugin instead:
 
 ```bash
 /plugin marketplace add padamson/playwright-rust
 /plugin install playwright-rs@playwright-rust
 ```
 
-Any of the three works; pick whichever fits your repo's convention.
-
-The snippet intentionally avoids verbatim code so it can't silently
-drift from the crate API — the canonical, compile-checked examples
-live in the crate-level rustdoc and the
-[`examples/`](https://github.com/padamson/playwright-rust/tree/main/crates/playwright/examples)
-directory.
-
----
-
-## Snippet (copy from here down into your CLAUDE.md)
-
-```markdown
-## Playwright-rs
-
-This project uses [playwright-rs](https://docs.rs/playwright-rs) for
-browser automation / E2E testing. The crate-level rustdoc on docs.rs
-is the canonical API tour; this section is the high-level conventions
-overlay.
-
-- **Object model:** `Playwright::launch()` → `BrowserType`
-  (`.chromium()` / `.firefox()` / `.webkit()`) → `Browser` →
-  `BrowserContext` → `Page` → `Locator`. Build locators with
-  `page.locator(...)` or the semantic `get_by_*` helpers, then chain
-  action / assertion methods.
-- **Use the `locator!()` macro** for selector literals — compile-time
-  validation catches typos, unbalanced brackets, and unknown engine
-  prefixes. Fall back to `&str` only for selectors computed at runtime.
-- **`expect()` assertions over manual polling.** They auto-retry within
-  the default timeout — never sprinkle `tokio::time::sleep` between
-  an action and a check.
-- **Builders / setters for options.** `goto`, `click`, `screenshot`,
-  `fill`, `tracing().start`, etc. take an `Options` struct. These are
-  `#[non_exhaustive]`, so struct literals won't compile — use the
-  type's `builder()` where it has one, otherwise chain setters off
-  `Default`/`new()` (e.g. `GetByRoleOptions::default().name("OK")`).
-- **`Result<T>` and `async/await` on `tokio`** throughout. One error
-  type: `playwright_rs::Error`.
-- **No reimplemented browser protocols.** This crate is a thin
-  JSON-RPC client to the upstream Playwright server; the API mirrors
-  playwright-python / java / .NET semantics. When in doubt, the
-  [upstream Playwright docs](https://playwright.dev/docs/api) are
-  authoritative.
-- **Structured data out of the page: typed `evaluate`.** The generic
-  `page.evaluate` deserializes the JS return value into your own serde
-  type — never return delimited strings from JS and split them in Rust.
-  `evaluate_value` (String) is for one-off scalar probes only.
-- **Drags go through `Locator::drag_to`** — it drives real
-  pointer-capture event chains, and its `target_position` option (an
-  offset from the target's top-left) handles drag-to-coordinate when
-  you pass the containing canvas/stage as the target. Held-button
-  `Mouse::move_to` sequences hang on headless Linux; don't use them
-  for drags.
-- **Waiting on arbitrary state:** `page.wait_for_function("() =>
-  window.app?.ready", None)` polls a JS predicate (locator form binds
-  the matched element as its argument) — prefer it over
-  evaluate-in-a-loop. **Calling back into Rust:**
-  `evaluate_with_callback` hands the expression a Rust closure JS can
-  call and await. **Session save/replay:** `storage_state(None)`
-  captures cookies/storage (options add passkeys + IndexedDB);
-  `set_storage_state` restores into any context (a replace, not a
-  merge).
-- **Newer surface worth knowing (options on docs.rs):** stable/redacted
-  screenshots (`animations(Disabled)`, `mask`, WebP); `Scroll::None` to
-  fail rather than auto-scroll; context-level events
-  (`BrowserContext::on_download` / `on_page_load` / `on_frame_*`,
-  `Browser::on_context`) for multi-tab fixtures; HAR capture
-  (`tracing().start_har` / `stop_har`, replayable via `route_from_har`);
-  external file drop (`Locator::drop`, vs intra-page `drag_to`);
-  ARIA-tree assertions (`expect_page(..).to_match_aria_snapshot`);
-  File System Access API testing (`page.fake_file_system()` fakes the
-  save/open pickers — don't hand-roll an init-script shim).
-
-### Debugging failures
-
-Wrap the test body in tracing → on failure, `playwright show-trace
-trace.zip` opens a visual debugger. See
-[`examples/trace_on_failure.rs`](https://github.com/padamson/playwright-rust/blob/main/crates/playwright/examples/trace_on_failure.rs)
-for the canonical Rust pattern (Rust has no async `Drop`, so cleanup
-is explicit).
-
-For programmatic trace inspection (CI bots, agent feedback loops),
-add [`playwright-rs-trace`](https://docs.rs/playwright-rs-trace) to
-`[dev-dependencies]`.
-
-### References
-
-- Full API: <https://docs.rs/playwright-rs>
-- Runnable examples: <https://github.com/padamson/playwright-rust/tree/main/crates/playwright/examples>
-- Upstream Playwright docs: <https://playwright.dev/docs/api>
-```
+Either route updates with one command. A pasted copy does not: it goes
+stale the moment the crate changes and then actively teaches the old API,
+which is why this file no longer carries the content. The skill is
+[`skills/playwright-rs-usage/`](../../skills/playwright-rs-usage/), and a
+build gate holds it to the crate's real API surface.

--- a/skills/playwright-rs-usage/SKILL.md
+++ b/skills/playwright-rs-usage/SKILL.md
@@ -3,7 +3,7 @@ name: playwright-rs-usage
 description: Procedural reference for using playwright-rs in Rust browser-automation code — object model (Browser/Context/Page/Locator), the `locator!()` macro, builder pattern for options, auto-wait semantics, adding the crate and installing its browsers, and how to capture / inspect traces for failure diagnosis. Use when writing tests or scripts with playwright-rs as a dependency. Loaded automatically when the current repo has playwright-rs in its Cargo.toml.
 license: Apache-2.0
 metadata:
-  version: "0.3.0"
+  version: "0.3.1"
 ---
 
 # Using playwright-rs
@@ -19,10 +19,16 @@ authoritative reference.
 rustdoc at <https://docs.rs/playwright-rs> — that's compile-checked
 against the actual code. This skill is the "what to reach for, what
 to avoid" overlay: durable conventions, not a method-by-method
-reference. The one Rust code block below is compile-checked by
-`cargo xtask verify-agent-docs`; the rest is prose that ages well
-because it talks in concepts (auto-wait, builder pattern) rather
-than specific method names.
+reference. Two build gates hold it to the crate: the Rust code block
+below is compiled against the real API, and every cargo feature and
+browser engine the crate exposes must be named somewhere in this file,
+so a capability cannot ship here undocumented.
+
+Neither gate checks that this prose is *accurate*. That residue is
+real. The text is written in concepts (auto-wait, builder pattern)
+rather than specific method names so it ages slowly, but when it and
+the crate disagree, the crate wins: check
+<https://docs.rs/playwright-rs> for the version you actually have.
 
 ## Before any of this works
 


### PR DESCRIPTION
`docs/agent/CLAUDE_SNIPPET.md` was a 111-line copy-paste duplicate of the
skill, kept in sync by hand. That is the shape that goes stale and then
actively teaches the old API, and it had already drifted. It becomes a
pointer, and `CLAUDE.md` now says not to reintroduce a second copy.

The README leads with `npx skills add padamson/playwright-rust` so any
skills-compatible agent can install it rather than only Claude Code, keeps
the plugin path as the Claude-specific alternative, and carries a skills.sh
badge. The `cp -r` instruction is gone repo-wide, along with the rustdoc
pointer to the retired snippet.

The skill's drift-discipline note now states what its two build gates
guarantee and, more usefully, what they do not: neither checks the prose is
accurate, so the crate wins when they disagree. Both versions moved to 0.3.1
together.

Also included, unrelated and in its own commit: `test_locator_wait_for_function_receives_the_matched_element`
measured elapsed time from when `set_content` returned, but the 300ms timer
it races starts when `set_content` runs the page script. The round trip fell
in the gap, so under load the assert fired on a correct wait (twice locally,
at 87ms elapsed). It now asks the page whether the flip happened, testing the
same property with no wall-clock at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)