### PR TITLE
Keep the contributor skills out of downstream installs

### DIFF
--- a/.claude/skills/doctest-conventions/SKILL.md
+++ b/.claude/skills/doctest-conventions/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: doctest-conventions
 description: Conventions for authoring rustdoc doctests in playwright-rust — the `no_run` annotation, module-level placement, hidden scaffolding lines, and how doctests are exercised in CI vs pre-commit.
+metadata:
+  internal: true
 ---
 
 # Doctest Conventions

--- a/.claude/skills/release-process/SKILL.md
+++ b/.claude/skills/release-process/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: release-process
 description: End-to-end release runbook for playwright-rust — version bump, supply-chain refresh, per-crate CHANGELOGs, tag-prefix routing for the three workspace crates, the safer push-then-tag workflow that waits for CI before publishing, and the post-release follow-ups.
+metadata:
+  internal: true
 ---
 
 # Release Process

--- a/.claude/skills/supply-chain/SKILL.md
+++ b/.claude/skills/supply-chain/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: supply-chain
 description: Procedure for keeping playwright-rust's cargo audit / cargo deny / cargo vet checks green when bumping the project's own version, when external crates change, and when a security advisory drops.
+metadata:
+  internal: true
 ---
 
 # Supply Chain & Release Hygiene

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,13 +67,26 @@ consequences worth knowing before they cost you time:
 ## Skills (procedural reference)
 
 Two audiences, kept apart by directory. `skills/` is what this repo
-ships to the world; `.claude/skills/` is contributor-only and never
-distributed. Claude Code auto-discovers only the latter, so the shipped
-skill is symlinked into it (`.claude/skills/playwright-rs-usage ->
-../../skills/playwright-rs-usage`) and there is still one source of
-truth. On a Windows checkout without symlink support that link lands as
-a stray text file and the skill simply does not auto-load in-repo, which
-costs nothing else.
+ships to the world; `.claude/skills/` is contributor-only. Claude Code
+auto-discovers only the latter, so the shipped skill is symlinked into it
+(`.claude/skills/playwright-rs-usage -> ../../skills/playwright-rs-usage`)
+and there is still one source of truth. On a Windows checkout without
+symlink support that link lands as a stray text file and the skill simply
+does not auto-load in-repo, which costs nothing else.
+
+**The directory split alone does not keep the contributor skills
+unpublished.** It gates the Claude Code plugin, whose default discovery
+reads `skills/` only, but the Agent Skills CLI scans `.claude/skills/`
+too and happily offered all four to downstream users. Each
+contributor-only skill therefore carries `metadata.internal: true`, which
+hides it from `npx skills add` unless the caller sets
+`INSTALL_INTERNAL_SKILLS=1`. **Any new skill added under
+`.claude/skills/` needs that line**, or it ships to everyone who installs
+from this repo. Note the value must be the boolean `true`, not the string
+`"true"`: the CLI ignores the quoted form, even though the Agent Skills
+spec describes `metadata` as string-to-string. Verify with
+`npx skills add <path-to-this-repo> --list`, which should report exactly
+one skill.
 
 Load these when the task touches their domain:
 


### PR DESCRIPTION
Dropping the marketplace `skills` array made the Claude Code plugin channel
correct: its default discovery reads `skills/` only. But the Agent Skills CLI
also scans `.claude/skills/`, which no manifest gates, so
`npx skills add padamson/playwright-rust` was offering four skills to
downstream users. Three of them are about releasing and auditing *this*
repository and are noise in a consumer's project.

`metadata.internal: true` on each contributor skill hides them, with
`INSTALL_INTERNAL_SKILLS=1` as the escape hatch for contributors who do want
them. Verified both directions: the CLI now reports one skill by default and
four with the variable set, and Claude Code still auto-loads all of them
in-repo.

The value must be the boolean `true`. The CLI ignores `"true"`, even though
the Agent Skills spec describes `metadata` as a string-to-string map. That
trap is recorded in CLAUDE.md along with the rule that any new
`.claude/skills/` entry needs the line, and the one-command check that
catches a miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)